### PR TITLE
Fix: filter out question sql

### DIFF
--- a/src/metabase/api/query_history.clj
+++ b/src/metabase/api/query_history.clj
@@ -15,6 +15,8 @@
                           (sql.helpers/join :query [:= :query.query_hash :query_execution.hash] )
                           (sql.helpers/join :metabase_database [:= :metabase_database.id :query_execution.database_id] )
                           (sql.helpers/where [:= :executor_id user-id])
+                          (sql.helpers/where [:is :dashboard_id nil])
+                          (sql.helpers/where [:is :card_id nil])
                           (sql.helpers/order-by [:started_at :desc])
                           (sql.helpers/limit 100)
                           )


### PR DESCRIPTION
discussed @Wzhipeng , we should filter out the sql from questions, only display history of sql that user inputs mannually